### PR TITLE
Updating dependency `parking_lot`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ smallvec = "^1.4.2"
 clap = "^3.0.0-beta.1"
 config = "^0.9"
 half = "^1.6.0"
-parking_lot = "^0.11.2"
+parking_lot = "0.12.1"
 colorgrad = "^0.5.0"
 
 [dependencies.rug]


### PR DESCRIPTION
Updating dependency `parking_lot` to
the same version as `rust_fractal_gui` to
fix compilation issues when building
`rust_fractal_gui`.  
Closes #43.